### PR TITLE
Improve emotion classification

### DIFF
--- a/internal/data_analysis/detect_emotions.py
+++ b/internal/data_analysis/detect_emotions.py
@@ -1,38 +1,37 @@
 import pandas as pd
 import operator
 
-# Class to store information about emotions and their strength for a wordset
 class emotion_data:  
-    def __init__(self, name, weight):  
-        self.name = name  
-        self.weight = weight 
-        self.count = 0
-    
-    # Increase the count for the number of times an emotion is represented
+    def __init__(self, name, colour):  
+        self.name = name
+        self.colour = colour
+        self.predominant_tweet_count = 0
+        
     def increase_count(self):
-        self.count = self.count + 1
+        self.predominant_tweet_count = self.predominant_tweet_count + 1
+        
+    def set_count(self, count):
+        self.predominant_tweet_count = count
+    
+    def get_bar_fraction(self, total_tweets):
+        return (self.predominant_tweet_count/total_tweets)*100
 
-    # Get the relative strength of an emotion
-    # By didviding the number of times that emotion is expressed, by the number of ways that that emotion can be expressed
-    def get_strength(self):
-        return round(self.count/self.weight,5)
 
-# From a list of words, Calculate the strengths of each of the measured emotions
-# Return this data as a list of emotions with strength data
-def get_emotions_from_wordlist(wordlist):
-    emolex_words = read_csv()
-    emotions = []
-    for em in emolex_words.emotion.unique():
-        weight = len(emolex_words[(emolex_words.association == 1) & (emolex_words.emotion == em)])
-        emotions.append( emotion_data(em, weight))
-    emolex_words = emolex_words.pivot(index='word', columns='emotion', values='association').reset_index()
-    for word in wordlist: 
-        data = emolex_words.loc[emolex_words.word == word.word]
+# From a tweet sentence, Calculate the strengths of each of the measured emotions
+# Find the emotion which best describes the tweet, and return it
+def get_emotion_of_tweet(emotions, emolex_words, tweet):
+    words = tweet.split()
+    emotion_tracker = create_emotion_set()
+    for word in words: 
+        data = emolex_words.loc[emolex_words.word == word]
         if data.empty == False:
-            for emotion in emotions:
+            for emotion in emotion_tracker:
                 if data[emotion.name].item() == 1.0:
                      emotion.increase_count()
-    return emotions
+    emotion_tracker = removelistelement(emotion_tracker, 'positive')
+    emotion_tracker = removelistelement(emotion_tracker, 'negative')
+    emotion_tracker.sort(key=lambda x: x.predominant_tweet_count)
+    return emotion_tracker[0].name
 
 # Remove an element from a list by its key value    
 def removelistelement(list, key):
@@ -42,20 +41,30 @@ def removelistelement(list, key):
             new_list.append(i)
     return new_list
 
-# Get the strongest emotions (exclusing posistive/negative) from a list of emotions
-# This function returns the 3 stringest emotions in the sorted list
-def get_strongest_emotions(emotion_list):
-    emotion_list = removelistelement(emotion_list, 'positive')
-    emotion_list = removelistelement(emotion_list, 'negative')
-    sorted_emotions = sorted(emotion_list, key=lambda x:-x.get_strength())
-
-    return sorted_emotions[0], sorted_emotions[1], sorted_emotions[2]
-    
-
-# Read the CSV file provided by the NRC Emotion Lexicon 
-# Return the data from the csv file
-def read_csv():
+# Read and rotate the NRC emotion lexicon dataset so it can be more easily alaysed
+def prepare_dataset():
     filepath = 'NRC-Emotion-Lexicon/NRC-Emotion-Lexicon-v0.92/NRC-Emotion-Lexicon-Wordlevel-v0.92.txt'
     emolex_df = pd.read_csv(filepath,  names=["word", "emotion", "association"], sep='\t')
+    emolex_df = emolex_df.pivot(index='word', columns='emotion', values='association').reset_index()
     return emolex_df
-  
+
+# Create and return a list of emotion objects to track emotion occurances
+def create_emotion_set():
+    emotions = [
+        emotion_data("anger",'#E5957C'), 
+        emotion_data("anticipation", '#D2C160'), 
+        emotion_data("disgust", '#A6C596'), 
+        emotion_data("fear", '#557B97'), 
+        emotion_data("joy", '#7CCCE5'), 
+        emotion_data("sadness", '#9A8AA8'), 
+        emotion_data("surprise", '#DCAB6E'),
+        emotion_data("trust", '#C09092'), 
+        
+    ]
+    return emotions
+
+# Create and return an 'other' emotion to describe less common emotions on the emotion chart
+def other_emotion(other_value):
+    other = emotion_data("other", '#8f8f8f')
+    other.set_count(other_value)
+    return other

--- a/static/styles/styles.css
+++ b/static/styles/styles.css
@@ -69,7 +69,7 @@ html {
 }
 
 .compare-content1 {
-    border-right: 1px solid #a19d9c !important; 
+    border-right: 2px solid #616161 !important; 
     vertical-align: top;
 }
 
@@ -91,7 +91,6 @@ html {
     
     .compare-content1 {
         border-right: None !important; 
-        border-bottom: 1px solid #a19d9c !important; 
         padding-bottom: 15px !important; 
         vertical-align: top;
     }
@@ -146,6 +145,12 @@ html {
         transform-origin: bottom center !important;
         margin-right: 70px;
     }
+    .emotion-chart{
+        width: 100%;
+    }
+    .all-emot {
+        font-size: 0px;
+    }
 }
 
 @media (min-width: 761px) {
@@ -175,6 +180,17 @@ html {
         right: 0;
         transform-origin: bottom center !important;
         margin-right: 130px;
+    }
+    .emotion-chart{
+        width: 75%;
+    }
+    .all-emot {
+        font-size: 13px;
+        font-weight: 500;
+    }
+
+    .emotionlabel {
+        padding-right: 5px !important;
     }
 }
 .rounded-pill-left {
@@ -243,4 +259,56 @@ html {
     font-weight: bold;
     margin-top:-25px;
 }
+
+.emotion-chart{
+    min-height: 30px;
+    display: flex;
+    border: 2px solid #6a6868;
+    border-radius: 50rem !important;
+    float:right;
+    margin-bottom: 7.5px;
+}
+
+.emot-first{
+    border-top-left-radius: 50rem !important;
+    border-bottom-left-radius: 50rem !important;
+}
+
+.emot-last{
+    flex-grow: 1;
+    border-top-right-radius: 50rem !important;
+    border-bottom-right-radius: 50rem !important;
+}
+
+.all-emot {
+    height: 100%;
+    text-align: center;
+    line-height: 30px;
+    padding-left: 2px;
+    padding-right: 2px;
+    min-width: fit-content;
+}
+
+.colour-inidicator {
+    height: 20px;
+    width: 20px;
+    background-color: #555;
+    border-radius: 20rem !important;
+    border: 2px solid #6a6868;
+    float:left;
+}
+
+.Column {
+    display: inline-block;
+    padding-right: 5px;
+    width: 49%;
+}
+
+.legendlabel {
+    padding-left: 3px;
+    vertical-align: middle;
+    height: 100%;
+    float:left;
+}
+
 /* End */

--- a/templates/tabs/analyse.html
+++ b/templates/tabs/analyse.html
@@ -76,16 +76,22 @@
             </td>
           </tr>
           <tr class="tr-content-mid">
-            <td class="td-content-desc">Strongest Emotions </td>
+            <td class="td-content-desc">Tweet Emotions </td>
           	<td class="td-content-data">
-							{% if result.most_used_data.strongest_emotions != [] %}
-                {% for item in result.most_used_data.strongest_emotions %}
-                  {{item.name}} 
-                  {% if not loop.last %},&nbsp;{%endif%}
+							<div class="emotion-chart flex-container">
+                {% for emotion in result.most_used_data.strongest_emotions %}
+                  <div class="{% if loop.index == 1 %}emot-first {% elif loop.last %}emot-last  {% endif %}all-emot" style="
+                  flex: 1 1 {{emotion.get_bar_fraction(result.tweetsetInfo.tweet_count)}}%; 
+                  background-color: {{emotion.colour}};">
+                    {{emotion.name.capitalize()}}
+                  </div>
                 {% endfor %}
-							{% else %}
-							  No emotions detected in the last 7 days of tweets<br>
-							{% endif %}
+              </div>
+              <div id="politicalLeaningDesc2" class="flex-wrap">
+                {% for emotion in result.most_used_data.strongest_emotions %}
+                  <div class="Column"><div class="colour-inidicator" style="background-color: {{emotion.colour}};"></div><p class="legendlabel">{{emotion.name.capitalize()}}</p></div>
+                {% endfor %}
+              </div>
             </td>
           </tr>
           <tr class="tr-content-mid">

--- a/templates/tabs/compare.html
+++ b/templates/tabs/compare.html
@@ -80,16 +80,22 @@
 						</td>
 					</tr>
 					<tr class="tr-content-mid">
-						<td class="td-content-desc">Strongest Emotions </td>
+						<td class="td-content-desc">Tweet Emotions </td>
 						<td class="td-content-data">
-							{% if result.most_used_data.strongest_emotions != [] %}
-								{% for item in result.most_used_data.strongest_emotions %}
-									{{item.name}} 
-									{% if not loop.last %},&nbsp;{%endif%}
+							<div class="emotion-chart flex-container">
+								{% for emotion in result.most_used_data.strongest_emotions %}
+								<div class="{% if loop.index == 1 %}emot-first {% elif loop.last %}emot-last  {% endif %}all-emot" style="
+								flex: 1 1 {{emotion.get_bar_fraction(result.tweetsetInfo.tweet_count)}}%; 
+								background-color: {{emotion.colour}};">
+									{{emotion.name.capitalize()}}
+								</div>
 								{% endfor %}
-							{% else %}
-								No emotions detected in the last 7 days of tweets<br>
-							{% endif %}
+							</div>
+							<div id="politicalLeaningDesc2" class="flex-wrap">
+								{% for emotion in result.most_used_data.strongest_emotions %}
+								<div class="Column"><div class="colour-inidicator" style="background-color: {{emotion.colour}};"></div><p class="legendlabel">{{emotion.name.capitalize()}}</p></div>
+								{% endfor %}
+							</div>
 						</td>
 					</tr>
 					<tr class="tr-content-mid">

--- a/test/test_data_analysis.py
+++ b/test/test_data_analysis.py
@@ -30,9 +30,19 @@ class TestSentiment(unittest.TestCase):
         self.assertEqual(sentiment, 'These tweets are overall much more Negative than Positive')
         
     
-    def test_get_emotions_from_wordlist(self):
-        detected_emotions = detect_emotions.get_emotions_from_wordlist(mock.mock_wordlist)
-        assert_emotionlists_are_equal(self, detected_emotions, mock.mock_emotionlist)
+    def test_get_emotion_of_tweet(self):
+        dataset = detect_emotions.prepare_dataset()
+        emotions = detect_emotions.create_emotion_set()
+        emotion = detect_emotions.get_emotion_of_tweet(emotions, dataset, mock.mock_tweetlist[1])
+        self.assertEqual(emotion, 'anger')
+        emotion = detect_emotions.get_emotion_of_tweet(emotions, dataset, mock.mock_tweetlist[12])
+        self.assertEqual(emotion, 'anticipation')
+        emotion = detect_emotions.get_emotion_of_tweet(emotions, dataset, mock.mock_tweetlist[8])
+        self.assertEqual(emotion, 'disgust')
+        emotion = detect_emotions.get_emotion_of_tweet(emotions, dataset, mock.mock_tweetlist[58])
+        self.assertEqual(emotion, 'fear')
+        emotion = detect_emotions.get_emotion_of_tweet(emotions, dataset, mock.mock_tweetlist[10])
+        self.assertEqual(emotion, 'joy')
 
     def test_removelistelement(self):
         word1 = detect_emotions.emotion_data('one',0)
@@ -43,10 +53,6 @@ class TestSentiment(unittest.TestCase):
             detect_emotions.removelistelement(test_list, "one"), 
             [word2]
         )
-            
-    def test_get_strongest_emotions(self):
-        strongest_emotions = detect_emotions.get_strongest_emotions(mock.mock_emotionlist)
-        assert_emotionlists_are_equal(self, strongest_emotions, mock.mock_strongest_emotions)
         
     def test_get_politics_from_wordlist(self):
         political_leaning = detect_political_leaning.get_politics_from_wordlist(mock.mock_wordlist)


### PR DESCRIPTION
Previously, emotion classification was reading anticipation joy and trust as the strongest emotions from any single tweet set.
I have solved this problem through a few steps:
1. Reading the emotion of each single tweet rather than the full set of tweets. Classify each tweet with a single emotion.
2. Graphically display emotion leaning as a bar chart of the prevalence of tweets with each predominant emotion. Only show the three strongest emotions, where they represent at least 5% of the base of tweets. 

Analyse (Desktop)
![image](https://user-images.githubusercontent.com/37660493/107438271-25aeab00-6b28-11eb-8571-4eb0d9e0a4f6.png)

Analyse (Mobile)
![image](https://user-images.githubusercontent.com/37660493/107438303-2e9f7c80-6b28-11eb-84e2-6618d775e33e.png)

Compare (Desktop)
![image](https://user-images.githubusercontent.com/37660493/107438084-e08a7900-6b27-11eb-9df0-0bf3287968bb.png)

Compare (Mobile)
![image](https://user-images.githubusercontent.com/37660493/107438368-4414a680-6b28-11eb-97ed-51649febcf0e.png)
![image](https://user-images.githubusercontent.com/37660493/107438387-4d057800-6b28-11eb-9f84-fa540d6fce37.png)
