### PR TITLE
Only show information messages on desktop

### DIFF
--- a/static/styles/styles.css
+++ b/static/styles/styles.css
@@ -176,6 +176,9 @@ html {
     .td-content-desc {
         width: 30%;
     }
+    .hoverInfo {
+        display: none;
+    }
 }
 
 @media (min-width: 761px) {
@@ -399,7 +402,6 @@ html {
     height: 15px;
 }
 
-
 [data-title]:hover:after {
     opacity: 1;
     transition: all 0.1s ease 0.5s;
@@ -417,28 +419,6 @@ html {
     z-index: 99999;
 }
 
-[auth-title] {
-    position: relative;
-}
-[auth-title]:hover:after {
-    opacity: 1;
-    transition: all 0.1s ease 0.5s;
-    visibility: visible;
-}
-[auth-title]:after {
-    content: attr(auth-title);
-    background-color: #D0CECE;
-    opacity: 0;
-    border: 2px solid #6a6868;
-    border-radius: 50rem !important;
-    padding: 5px 10px 5px 10px;
-    position:absolute !important; 
-    min-width: 250px; 
-    z-index: 99999;
-}
-[auth-title] {
-    position: relative;
-}
 .informational_icon {
     width: 15px;
     height: 15px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,29 +38,6 @@
 				document.getElementById("loading").style.display = "block";
 				$(this).parent().trigger('submit')
 			}
-			$(document).ready(function() {
-
-				function showBox(text) {
-					$("#divpolitical").html(text);
-					$("#divpolitical").css("background", "#D0CECE");
-					$("#divpolitical").css("border", "2px solid #6a6868");
-				}
-				function hidebox() {
-					$("#divpolitical").html("");
-					$("#divpolitical").css("background", "transparent");
-					$("#divpolitical").css("border", "0px");
-				}
-				$("#politicalBot").mouseover(function() {  showBox("Manually labeled political bots and accounts involved in follow trains that systematically delete content."); });
-				$("#fakeFollower").mouseover(function() {  showBox("Bots purchased to increase follower counts."); });
-				$("#spammerBot").mouseover(function() {    showBox("Accounts labeled as spambots from several datasets."); });
-				$("#financialBot").mouseover(function() {  showBox("Bots that post using cashtags."); });
-				$("#flaggedAsFake").mouseover(function() { showBox("Bots identified from botwiki.org."); });
-				$("#politicalBot").mouseout(function() {   hidebox(); });
-				$("#fakeFollower").mouseout(function() {   hidebox(); });
-				$("#spammerBot").mouseout(function() {     hidebox(); });
-				$("#financialBot").mouseout(function() {   hidebox(); });
-				$("#flaggedAsFake").mouseout(function() {  hidebox(); });
-			});
 		</script>
 		<nav class="navbar navbar-expand-lg fixed-top flex-nowrap">  
         	<img src="{{ url_for('static',filename='images/fyplogo.png') }}" alt="logo" class="logo"/>

--- a/templates/tabs/analyse_account.html
+++ b/templates/tabs/analyse_account.html
@@ -119,42 +119,42 @@
               {% if result.authenticity_measures != None %}
               <tr class="tr-content-mid">
               <td colspan="5" style="text-align: center; padding-top: 25px; padding-bottom: 5px;"><b>Probability of {{result.tweetsetInfo.term}} being Different Twitter Bot Types</b></td>
-              </tr>
-              <tr class="tr-content-mid">
-                <td style="text-align: center; border-right: 1px solid #a19d9c;">
-                  Political <div class="condbreak"><br></div>Bot<div class="condbreak"><br></div>
-                  <img id="politicalBot" name="political" src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
-                  <br>
+              </tr class="tr-content-mid">
+              <td style="text-align: center; border-right: 1px solid #a19d9c;">
+                  Political <div class="condbreak"><br></div>Bot
+                  <a class="hoverInfo" style="width: 15px;color:#000000;text-decoration:none" data-title="Manually labeled political bots and accounts involved in follow trains that systematically delete content.">
+                    <img src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
+                  </a><br>
                   <b>{{result.authenticity_measures.probability(result.authenticity_measures.astroturf)}}%</b>
                 </td>
                 <td style="text-align: center; border-right: 1px solid #a19d9c;">
-                  Fake <div class="condbreak"><br></div>Follower<div class="condbreak"><br></div>
-                  <img id="fakeFollower" src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
-                  <br>
+                  Fake <div class="condbreak"><br></div>Follower
+                  <a class="hoverInfo" style="width: 15px;color:#000000;text-decoration:none" data-title="Bots purchased to increase follower counts.">
+                    <img src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
+                  </a><br>
                   <b>{{result.authenticity_measures.probability(result.authenticity_measures.fake_follower)}}%<b>
                 </td>
                 <td style="text-align: center; border-right: 1px solid #a19d9c;">
-                  Spammer <div class="condbreak"><br></div>Bot<div class="condbreak"><br></div>
-                  <img id="spammerBot" src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
-                  <br>
+                  Spammer <div class="condbreak"><br></div>Bot
+                  <a class="hoverInfo" style="width: 15px;color:#000000;text-decoration:none" data-title="Accounts labeled as spambots from several datasets.">
+                    <img src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
+                  </a><br>
                   <b>{{result.authenticity_measures.probability(result.authenticity_measures.spammer)}}%</b>
                 </td>
                 <td style="text-align: center; border-right: 1px solid #a19d9c;">
-                  Financial <div class="condbreak"><br></div>Bot<div class="condbreak"><br></div>
-                  <img id="financialBot" src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
-                  <br>
+                  Financial <div class="condbreak"><br></div>Bot
+                  <a class="hoverInfo" style="width: 15px;color:#000000;text-decoration:none" data-title="Bots that post using cashtags.">
+                    <img src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
+                  </a><br>
                   <b>{{result.authenticity_measures.probability(result.authenticity_measures.financial)}}%<b>
                 </td>
                 <td style="text-align: center;">
-                  Flagged <div class="condbreak"><br></div>as Fake<div class="condbreak"><br></div>
-                  <img id="flaggedAsFake" src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
-                  <br>
+                  Flagged <div class="condbreak"><br></div>as Fake
+                  <a class="hoverInfo" style="width: 15px;color:#000000;text-decoration:none" data-title="Bots identified from botwiki.org.">
+                    <img src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
+                  </a><br>
                   <b>{{result.authenticity_measures.probability(result.authenticity_measures.self_declared)}}%</b>
                 </td>
-              </tr>
-              <tr>
-              <td colspan="5"><div id="divpolitical" style="margin-top: 10px;height: 30px; line-height:30px; text-align: center; border-radius: 50rem; padding-left: 10px;"></div></td>
-              </tr>
               {% endif %}
             </table>
           </div>
@@ -171,7 +171,7 @@
             </tr>
               <tr>
                 <td class="td-content-desc">Positivity
-              <a class="tip" style="width: 15px;color:#000000;text-decoration:none" data-title="How Positive or Negative this set of tweets is.">
+              <a class="hoverInfo" style="width: 15px;color:#000000;text-decoration:none" data-title="How Positive or Negative this set of tweets is.">
                 <img src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
               </a>
             </td>
@@ -179,7 +179,7 @@
               </tr>
               <tr class="tr-content-mid">
                 <td class="td-content-desc">Political Leaning
-              <a class="tip" style="width: 15px;text-decoration:none" data-title="Where this set of tweets falls on the spectrum from left/liberal to right/conservative.">
+              <a class="hoverInfo" style="width: 15px;text-decoration:none" data-title="Where this set of tweets falls on the spectrum from left/liberal to right/conservative.">
                 <img data-title="Where this set of tweets falls on the spectrum from left/liberal to right/conservative." src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
               </a>
             </td>
@@ -203,7 +203,7 @@
               </tr>
               <tr class="tr-content-mid">
                 <td class="td-content-desc">Tweet Emotions
-                  <a class="tip" style="width: 15px;color:#000000;text-decoration:none" data-title="The percentages of the set of tweets which is associated with various emotions.">
+                  <a class="hoverInfo" style="width: 15px;color:#000000;text-decoration:none" data-title="The percentages of the set of tweets which is associated with various emotions.">
                     <img src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
                   </a>
                 </td>

--- a/templates/tabs/analyse_tweets.html
+++ b/templates/tabs/analyse_tweets.html
@@ -61,7 +61,7 @@
         <table id="result_section_2" style="width:100%;">
           <tr>
             <td class="td-content-desc">Positivity
-              <a class="tip" style="width: 15px;color:#000000;text-decoration:none" data-title="How Positive or Negative this set of tweets is.">
+              <a class="hoverInfo" style="width: 15px;color:#000000;text-decoration:none" data-title="How Positive or Negative this set of tweets is.">
                 <img src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
               </a>
             </td>
@@ -69,7 +69,7 @@
           </tr>
           <tr class="tr-content-mid">
             <td class="td-content-desc">Political Leaning
-              <a class="tip" style="width: 15px;text-decoration:none" data-title="Where this set of tweets falls on the spectrum from left/liberal to right/conservative.">
+              <a class="hoverInfo" style="width: 15px;text-decoration:none" data-title="Where this set of tweets falls on the spectrum from left/liberal to right/conservative.">
                 <img src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
               </a>
             </td>
@@ -94,7 +94,7 @@
           </tr>
           <tr class="tr-content-mid">
             <td class="td-content-desc">Tweet Emotions
-              <a class="tip" style="width: 15px;color:#000000;text-decoration:none" data-title="The percentages of the set of tweets which is associated with various emotions.">
+              <a class="hoverInfo" style="width: 15px;color:#000000;text-decoration:none" data-title="The percentages of the set of tweets which is associated with various emotions.">
                 <img src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
               </a>
             </td>

--- a/templates/tabs/compare_tweets.html
+++ b/templates/tabs/compare_tweets.html
@@ -68,7 +68,7 @@
 				<table Name="result_section_2_{{loop.index}}" style="width:100%;">
 					<tr>
 						<td class="td-content-desc">Positivity
-							<a class="tip" style="width: 15px;color:#000000;text-decoration:none" data-title="How Positive or Negative this set of tweets is.">
+							<a class="hoverInfo" style="width: 15px;color:#000000;text-decoration:none" data-title="How Positive or Negative this set of tweets is.">
 								<img src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
 							</a>
 						</td>
@@ -76,7 +76,7 @@
 					</tr>
 					<tr class="tr-content-mid">
 						<td class="td-content-desc">Political Leaning
-							<a class="tip" style="width: 15px;text-decoration:none" data-title="Where this set of tweets falls on the spectrum from left/liberal to right/conservative.">
+							<a class="hoverInfo" style="width: 15px;text-decoration:none" data-title="Where this set of tweets falls on the spectrum from left/liberal to right/conservative.">
 								<img data-title="Where this set of tweets falls on the spectrum from left/liberal to right/conservative." src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
 							</a>
 						</td>
@@ -100,7 +100,7 @@
 					</tr>
 					<tr class="tr-content-mid">
 						<td class="td-content-desc">Tweet Emotions
-							<a class="tip" style="width: 15px;color:#000000;text-decoration:none" data-title="The percentages of the set of tweets which is associated with various emotions.">
+							<a class="hoverInfo" style="width: 15px;color:#000000;text-decoration:none" data-title="The percentages of the set of tweets which is associated with various emotions.">
 								<img src="{{ url_for('static',filename='images/info_icon.png') }}" alt="Verified" class="informational_icon"/>
 							</a>
 						</td>


### PR DESCRIPTION
The previous PR, #26 , allowed information bubbles to sho on mobile - this added a lot of styling complications.
This PR sets informational bubbles to only be accessable in screen sizes over 760px width (Desktop)
This also saves the hassle of configuring the mouseover event to ork with touchscreen, and allows the bubble to be more naturally located and shaped. 
E.g:
![image](https://user-images.githubusercontent.com/37660493/107867660-929daa00-6e74-11eb-9e17-dfe270c530f9.png)
![image](https://user-images.githubusercontent.com/37660493/107867668-a8ab6a80-6e74-11eb-8fcd-7606168c1b11.png)

This commit can be reverted if the previous implementation turns out to be preferable
