### PR TITLE
Set info messages to yellow, Error messages to red

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ def analyse_tweets():
     return render_template('tabs/analyse_tweets.html', result=resultitem)
 
 def analyse_err(msg):
-    flash(msg)
+    flash(msg, 'error')
     return render_template('tabs/analyse_tweets.html', result=None)
     
 # If a request has been made, render the results on the page
@@ -47,7 +47,7 @@ def analyseQuery():
         return analyse_err("No tweets found for this query, please try again")
     
     if err != None:
-        flash("Analysing fewer than 20 tweets will lead to less accurate results. Only "+str(resultitem.tweetsetInfo.tweet_count)+" tweets analysed for "+str(resultitem.tweetsetInfo.term))
+        flash("Analysing fewer than 20 tweets will lead to less accurate results. Only "+str(resultitem.tweetsetInfo.tweet_count)+" tweets analysed for "+str(resultitem.tweetsetInfo.term),'info')
         
     return render_template('tabs/analyse_tweets.html', result=resultitem)   
 
@@ -57,7 +57,7 @@ def compare():
     return render_template('tabs/compare_tweets.html', resultlist=resultlist)
 
 def compare_err(msg, column):
-    flash(msg, "category"+column)
+    flash(msg, "column"+column+"_error")
     return render_template('tabs/compare_tweets.html', resultlist=resultlist) 
 
 # If a request has been made, render the results on the page
@@ -84,7 +84,7 @@ def compareQuery():
         resultlist[1] = result
         
     if err != None:
-        flash("Analysing fewer than 20 tweets will lead to less accurate results. Only "+str(result.tweetsetInfo.tweet_count)+" tweets analysed for "+str(result.tweetsetInfo.term))
+        flash("Analysing fewer than 20 tweets will lead to less accurate results. Only "+str(result.tweetsetInfo.tweet_count)+" tweets analysed for "+str(result.tweetsetInfo.term), "column"+lp+"_info")
     
     return render_template('tabs/compare_tweets.html', resultlist=resultlist)   
 
@@ -95,7 +95,7 @@ def analyse_acc():
     return render_template('tabs/analyse_account.html', result=resultitem)
 
 def analyse_acc_err(msg):
-    flash(msg)
+    flash(msg, 'error')
     return render_template('tabs/analyse_account.html', result=None)
 
 # If a request has been made, render the results on the page
@@ -108,7 +108,7 @@ def analyse_acc_Query():
     country = request.form.get('countryDataset', 'global')
     resultitem, err = analyse_account(term, country)
     if err != None:
-        flash("Analysing fewer than 20 tweets will lead to less accurate results. Only "+str(resultitem.tweetsetInfo.tweet_count)+" tweets analysed for "+str(resultitem.tweetsetInfo.term))
+        flash("Analysing fewer than 20 tweets will lead to less accurate results. Only "+str(resultitem.tweetsetInfo.tweet_count)+" tweets analysed for "+str(resultitem.tweetsetInfo.term),'info')
     
     if resultitem == "noHashorAt":
         return analyse_acc_err("You must enter a @user handle, please try again")

--- a/static/styles/styles.css
+++ b/static/styles/styles.css
@@ -376,10 +376,17 @@ html {
     float:left;
 }
 
-.alert {
+.error {
     background-color: #e5957c !important;
     border-color: #a96b58 !important;
     color: #50342b !important;
+    font-weight: bold !important;
+}
+
+.info {
+    background-color: #ffd390 !important;
+    border-color: #FCB040 !important;
+    color: #835c21 !important;
     font-weight: bold !important;
 }
 
@@ -433,7 +440,4 @@ html {
     height: 15px;
 }
 
-.displaybtn {
-    background: #ffffff;
-}
 /* End */

--- a/templates/tabs/analyse_account.html
+++ b/templates/tabs/analyse_account.html
@@ -5,10 +5,10 @@
 {% block tab3 %}" style="background: #AFABAB; border-color: #AFABAB; font-weight: bold;{% endblock %}
 {% block content %}
   <div class="bigtab d-flex flex-column">
-  {% with messages = get_flashed_messages() %}
+  {% with messages = get_flashed_messages(with_categories=true) %}
 	  {% if messages %}
-	    {% for message in messages %}
-		  <div class="alert alert-warning alert-dismissible" role="alert">
+	    {% for category, message in messages %}
+		  <div class="{{category}} alert alert-warning alert-dismissible" role="alert">
 		  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
 			{{message}}
 		  </div>

--- a/templates/tabs/analyse_tweets.html
+++ b/templates/tabs/analyse_tweets.html
@@ -5,10 +5,10 @@
 {% block tab3 %}{% endblock %}
 {% block content %}
   <div class="bigtab d-flex flex-column">
-  {% with messages = get_flashed_messages() %}
+  {% with messages = get_flashed_messages(with_categories=true) %}
 	  {% if messages %}
-	    {% for message in messages %}
-		  <div class="alert alert-warning alert-dismissible" role="alert">
+	    {% for category, message in messages %}
+		  <div class="{{category}} alert alert-warning alert-dismissible" role="alert">
 		  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
 			{{message}}
 		  </div>

--- a/templates/tabs/compare_tweets.html
+++ b/templates/tabs/compare_tweets.html
@@ -9,15 +9,26 @@
         {% for result in resultlist %}
 			{% if loop.index == 1 %}
 				<div class="col-12 col-md-6 compare-content1">
-				{% set category = "category1"%}
+				{% set column = "column1"%}
 			{% else %}
 				<div class="col-12 col-md-6 compare-content2">
-				{% set category = "category2"%}
+				{% set column = "column2"%}
 			{%endif%}
-			{% with messages = get_flashed_messages(category_filter=[category]) %}
+			{% with messages = get_flashed_messages(category_filter=[column+"_info"]) %}
 				{% if messages %}
 					{% for message in messages %}
-					<div class="alert alert-warning alert-dismissible" role="alert">
+					<div class="info alert alert-warning alert-dismissible" role="alert">
+						<button type="button" class="close" data-dismiss="alert" aria-label="Close">
+						<span aria-hidden="true">×</span></button>
+						{{message}}
+					</div>
+					{% endfor %}
+				{% endif %}
+			{% endwith %}
+			{% with messages = get_flashed_messages(category_filter=[column+"_error"]) %}
+				{% if messages %}
+					{% for message in messages %}
+					<div class="error alert alert-warning alert-dismissible" role="alert">
 						<button type="button" class="close" data-dismiss="alert" aria-label="Close">
 						<span aria-hidden="true">×</span></button>
 						{{message}}


### PR DESCRIPTION
Previously, all alert messages were set to be have red backgrounds. 
This PR updates info messages ( When fewer than 20 tweets are found ) so that they display as yellow and not red. 

Error Message:
![image](https://user-images.githubusercontent.com/37660493/108603205-83e85300-739e-11eb-8e19-73a88c41ca99.png)

Info Message:
![image](https://user-images.githubusercontent.com/37660493/108603213-9793b980-739e-11eb-8b4b-615fc48d24b4.png)
