### PR TITLE
Add see tweets button

### DIFF
--- a/static/styles/styles.css
+++ b/static/styles/styles.css
@@ -472,4 +472,17 @@ html {
     height: 15px;
 }
 
+.seetweetsbtn{
+    background:#908C8C; 
+    border-radius: 20rem; 
+    color: black; 
+    padding:2px 8px 2px 5px;
+    text-decoration: none;
+}
+
+.seetweetsbtn:hover {
+    background:#575757; 
+    color: white; 
+    text-decoration: none;
+}
 /* End */

--- a/templates/tabs/analyse_account.html
+++ b/templates/tabs/analyse_account.html
@@ -190,7 +190,17 @@
             <table style="width:100%;">
             <tr>
             <div>
-              <div style="text-align:center; padding-top:7.5px;">Account Analysed: <b>{{result.tweetsetInfo.term}}</b></div>
+              <div style="text-align:center; padding-top:7.5px; ">Account Analysed: <b>{{result.tweetsetInfo.term}}</b>
+              &nbsp;<a class="seetweetsbtn"
+                  {% if result.tweetsetInfo.type == 'usr' %}
+                    href="https://twitter.com/{{result.tweetsetInfo.term}}"
+                  {% else  %}
+                    href="https://twitter.com/search?q={{result.tweetsetInfo.term| urlencode }}&src=typed_query&f=live"
+                  {% endif %}
+                  target="_blank">
+                  See Tweets
+                </a>
+              </div>
               <div style="text-align:center;">Found <b>{{result.tweetsetInfo.tweet_count}} tweets</b> from the last 7 days with <b>{{result.tweetsetInfo.word_count}}</b> unique words used</div>
               <div style="text-align:center;">Politics Analysed with a dataset from <b>{{result.political_sentiment_data.dataset_country}}</b></div>
               <br>

--- a/templates/tabs/analyse_tweets.html
+++ b/templates/tabs/analyse_tweets.html
@@ -59,7 +59,17 @@
       </div>
       {% if result != None %}
       <div id="result_section_1">
-        <div style="text-align:center; padding-top:7.5px;">Search Term: <b>{{result.tweetsetInfo.term}}</b></div>
+        <div style="text-align:center; padding-top:7.5px; ">Search Term: <b>{{result.tweetsetInfo.term}}</b>
+        &nbsp;<a class="seetweetsbtn"
+            {% if result.tweetsetInfo.type == 'usr' %}
+              href="https://twitter.com/{{result.tweetsetInfo.term}}"
+            {% else  %}
+              href="https://twitter.com/search?q={{result.tweetsetInfo.term| urlencode }}&src=typed_query&f=live"
+            {% endif %}
+            target="_blank">
+            See Tweets
+          </a>
+        </div>
         <div style="text-align:center;">Found <b>{{result.tweetsetInfo.tweet_count}} tweets</b> from the last 7 days with <b>{{result.tweetsetInfo.word_count}}</b> unique words used</div>
         <div style="text-align:center;">Politics Analysed with a dataset from <b>{{result.political_sentiment_data.dataset_country}}</b></div>
         <br>
@@ -153,7 +163,11 @@
                   {{result.tweetsetInfo.most_retweeted.retweet_count}}<br>
                   </div>
                 {% else %}
+                  {% if result.tweetsetInfo.type == 'usr' %}
                   {{result.tweetsetInfo.term}} has not written an original tweet, only retweeted tweets by others in the last 7 days
+                  {% elif result.tweetsetInfo.type == 'tag'  %}
+                  {{result.tweetsetInfo.term}} has had too many recent tweets to easily identify the most popular tweet
+                  {% endif %}
                 {% endif %}
             </td>
           </tr>

--- a/templates/tabs/compare_tweets.html
+++ b/templates/tabs/compare_tweets.html
@@ -77,10 +77,20 @@
 			</div>
             {% if result != None %}
       		<div Name="result_section_1_{{loop.index}}">
-              <div style="text-align:center;">Search Term: <b>{{result.tweetsetInfo.term}}</b></div>
-              <div style="text-align:center;">Found <b>{{result.tweetsetInfo.tweet_count}} tweets</b> from the last 7 days with <b>{{result.tweetsetInfo.word_count}}</b> unique words used</div>
-              <div style="text-align:center;">Politics Analysed with a dataset from <b>{{result.political_sentiment_data.dataset_country}}</b></div>
-			  <br>
+              	<div style="text-align:center; padding-top:7.5px; ">Search Term: <b>{{result.tweetsetInfo.term}}</b>
+				&nbsp;<a class="seetweetsbtn"
+					{% if result.tweetsetInfo.type == 'usr' %}
+					href="https://twitter.com/{{result.tweetsetInfo.term}}"
+					{% else  %}
+					href="https://twitter.com/search?q={{result.tweetsetInfo.term| urlencode }}&src=typed_query&f=live"
+					{% endif %}
+					target="_blank">
+					See Tweets
+				</a>
+				</div>
+			  	<div style="text-align:center;">Found <b>{{result.tweetsetInfo.tweet_count}} tweets</b> from the last 7 days with <b>{{result.tweetsetInfo.word_count}}</b> unique words used</div>
+             	<div style="text-align:center;">Politics Analysed with a dataset from <b>{{result.political_sentiment_data.dataset_country}}</b></div>
+			  	<br>
 				<table Name="result_section_2_{{loop.index}}" style="width:100%;">
 					<tr>
 						<td class="td-content-desc">Sentiment
@@ -170,7 +180,11 @@
 							{{result.tweetsetInfo.most_retweeted.retweet_count}}<br>
 							</div>
 							{% else %}
-							{{result.tweetsetInfo.term}} has not written an original tweet, only retweeted tweets by others in the last 7 days
+								{% if result.tweetsetInfo.type == 'usr' %}
+								{{result.tweetsetInfo.term}} has not written an original tweet, only retweeted tweets by others in the last 7 days
+								{% elif result.tweetsetInfo.type == 'tag'  %}
+								{{result.tweetsetInfo.term}} has had too many recent tweets to easily identify the most popular tweet
+								{% endif %}
 							{% endif %}
 						</td>
 					</tr>


### PR DESCRIPTION
Add button to link to the set of tweets being analysed. 
For a user this button will direct to the twitter page of the user, e.g:
![image](https://user-images.githubusercontent.com/37660493/109327208-fdc18600-784f-11eb-92c7-27ad525dae56.png)
link: https://twitter.com/@berniesanders

For a hashtag the button will direct to the recent search query page for that hashtag, e.g:
![Uploading image.png…]()
link: https://twitter.com/search?q=%23limerick&src=typed_query&f=live