### PR TITLE
update accidentally removed fields

### DIFF
--- a/internal/political_leaning/political_leaning_ml.py
+++ b/internal/political_leaning/political_leaning_ml.py
@@ -25,7 +25,7 @@ def build_ml_model(country):
     elif country == "uk":
         data = pd.read_csv(r'datasets/ml_training/uk_parties_full_set.csv')
     elif country == "us":
-        data = pd.read_csv(r'datasets/ml_training/kaggle_US_dataset_modified.csv')
+        data = pd.read_csv(r'datasets/ml_training/us_parties_full_set.csv')
     else:
         data = pd.read_csv(r'datasets/ml_training/ie_uk_us_full_set.csv')
     

--- a/templates/tabs/analyse_account.html
+++ b/templates/tabs/analyse_account.html
@@ -309,6 +309,19 @@
                 </td>
               </tr>
               <tr class="tr-content-mid">
+                <td class="td-content-desc">Most Used Hashtags </td>
+                <td class="td-content-data">
+                  {% if result.most_used_data.most_used_hashtags != [] %}
+                    {% for item in result.most_used_data.most_used_hashtags %}
+                      {{item.word}}
+                      {% if not loop.last %},&nbsp;{%endif%}
+                    {% endfor %}
+                  {% else %}
+                    No hashtags used in the last 7 days of tweets<br>
+                  {% endif %}
+                </td>
+              </tr>
+              <tr class="tr-content-mid">
                 <td class="td-content-desc">Most Tagged Accounts </td>
                 <td class="td-content-data">
                   {% if result.most_used_data.most_tagged_users != [] %}

--- a/templates/tabs/analyse_tweets.html
+++ b/templates/tabs/analyse_tweets.html
@@ -214,6 +214,19 @@
 							{% endif %}
             </td>
           </tr>
+          <tr class="tr-content-mid">
+            <td class="td-content-desc">Most Tagged Accounts </td>
+            <td class="td-content-data">
+              {% if result.most_used_data.most_tagged_users != [] %}
+                {% for item in result.most_used_data.most_tagged_users %}
+                  {{item.word}}
+                  {% if not loop.last %},&nbsp;{%endif%}
+                {% endfor %}
+              {% else %}
+                No accounts tagged used in the last 7 days of tweets<br>
+              {% endif %}
+            </td>
+          </tr>
         </table>
         <div id="result_section_3" style="text-align:center; padding-top: 10px;">
           <a class="btn btn-primary" 

--- a/templates/tabs/compare_tweets.html
+++ b/templates/tabs/compare_tweets.html
@@ -231,6 +231,19 @@
 						{% endif %}
 						</td>
 					</tr>
+					<tr class="tr-content-mid">
+						<td class="td-content-desc">Most Tagged Accounts </td>
+						<td class="td-content-data">
+						{% if result.most_used_data.most_tagged_users != [] %}
+							{% for item in result.most_used_data.most_tagged_users %}
+							{{item.word}}
+							{% if not loop.last %},&nbsp;{%endif%}
+							{% endfor %}
+						{% else %}
+							No accounts tagged used in the last 7 days of tweets<br>
+						{% endif %}
+						</td>
+					</tr>
 				</table>
            </div>
         <div Name="result_section_3_{{loop.index}}" style="text-align:center; padding-top: 10px;">

--- a/templates/tabs/home.html
+++ b/templates/tabs/home.html
@@ -23,6 +23,7 @@
             <li>Most Used Emojis in Tweet-set</li>
             <li>Most Used Words in Tweet-set</li>
             <li>Most Used Hashtags in Tweet-set</li>
+            <li>Most Tagged Users in Tweet-set</li>
           </ul>This data can be used to see interesting trends or patterns within a hashtag, and to observe interesting data about how public figures use twitter.<br>
         </div>
       </div>
@@ -39,6 +40,7 @@
             <li>Most Used Emojis in Tweet-set</li>
             <li>Most Used Words in Tweet-set</li>
             <li>Most Used Hashtags in Tweet-set</li>
+            <li>Most Tagged Users in Tweet-set</li>
           </ul>This data can be used to see how different issues are discussed in different ways on twitter, and determine how different groups or political figures use different words, emotions and sentiments within their tweets
         </div>
       </div>
@@ -55,6 +57,7 @@
             <li>Most Used Emojis in Tweet-set</li>
             <li>Most Used Words in Tweet-set</li>
             <li>Most Used Hashtags in Tweet-set</li>
+            <li>Most Tagged Users in Tweet-set</li>
           </ul>As well as:
           <ul>
             <li>Twitter User Account Info</li>
@@ -107,6 +110,7 @@
           <li>Most Used Emojis in Tweet-set: The most frequently used emojis within the set of tweets.</li>
           <li>Most Used Words in Tweet-set: The most frequently used words within the set of tweets.</li>
           <li>Most Used Hashtags in Tweet-set: The most frequently used hashtags within the set of tweets.</li>
+          <li>Most Tagged Users in Tweet-set: The most frequently tagged twitter users within the set of tweets.</li>
         </ul>
       </div>
       <div>When analysing a twitter account, this additional data can be seen:</div>


### PR DESCRIPTION
The 'Most Tagged Accounts' Field was missing from the analyse tweets and analyse account pages,
and the 'most used hashtags' field was missing from the analyse account page.
These missing fields were added back to the relevant pages, and the home page was updated to include refences to the 'Most Tagged Accounts' field

Home Page
![image](https://user-images.githubusercontent.com/37660493/111850067-21d02e80-8907-11eb-8428-94a2886ed3ee.png)
![image](https://user-images.githubusercontent.com/37660493/111850088-314f7780-8907-11eb-8c1d-56f249234e29.png)
![image](https://user-images.githubusercontent.com/37660493/111850099-37ddef00-8907-11eb-895d-6e8b317eafa2.png)

Analyse Tweets
![image](https://user-images.githubusercontent.com/37660493/111850152-665bca00-8907-11eb-8d54-6cfd1cf1b00b.png)

Compare Tweets
![image](https://user-images.githubusercontent.com/37660493/111850176-78d60380-8907-11eb-9e48-0de5a46765ae.png)

Analyse Account
![image](https://user-images.githubusercontent.com/37660493/111850208-91deb480-8907-11eb-9464-5b145827ee86.png)
